### PR TITLE
Fix dk2nu example for Python 2 compatibility

### DIFF
--- a/examples/dk2nu_example.py
+++ b/examples/dk2nu_example.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+
+import io
 import os
-from pathlib import Path
 
 import ROOT
 
@@ -15,17 +17,17 @@ RHC_PATTERN = "/pnfs/uboone/persistent/users/bnayak/flux_files/uboone_beamsim_g4
 fhc_pattern = os.environ.get("UB_NUMIANA_FHC_PATTERN", FHC_PATTERN)
 rhc_pattern = os.environ.get("UB_NUMIANA_RHC_PATTERN", RHC_PATTERN)
 
-filelist_path = Path(os.environ.get("UB_NUMIANA_FILELIST", "dk2nu_g4104_fhc_rhc.files"))
+filelist_path = os.environ.get("UB_NUMIANA_FILELIST", "dk2nu_g4104_fhc_rhc.files")
 outfile = os.environ.get("UB_NUMIANA_OUTFILE", "dk2nu_g4104_fhc_rhc.root")
 
-with filelist_path.open("w", encoding="utf-8") as handle:
-    handle.write(f"{fhc_pattern}\n")
-    handle.write(f"{rhc_pattern}\n")
+with io.open(filelist_path, "w", encoding="utf-8") as handle:
+    handle.write(u"{}\n".format(fhc_pattern))
+    handle.write(u"{}\n".format(rhc_pattern))
 
-print(f"Wrote horn-polarity patterns to {filelist_path}")
-print(f"  FHC: {fhc_pattern}")
-print(f"  RHC: {rhc_pattern}")
-print(f"Output will be stored in {outfile}")
+print("Wrote horn-polarity patterns to {}".format(filelist_path))
+print("  FHC: {}".format(fhc_pattern))
+print("  RHC: {}".format(rhc_pattern))
+print("Output will be stored in {}".format(outfile))
 
 flux = ROOT.Dk2NuFlux(True, str(filelist_path), outfile)
 flux.CalculateFlux()


### PR DESCRIPTION
## Summary
- replace f-strings and pathlib usage in the dk2nu example with Python 2 compatible code
- ensure the example writes UTF-8 encoded patterns while keeping the existing behavior

## Testing
- `python examples/dk2nu_example.py` *(fails: ModuleNotFoundError: No module named 'ROOT')*

------
https://chatgpt.com/codex/tasks/task_e_68e51583f748832e955d26099fd8e35b